### PR TITLE
drm-upai/xe_drm_prelim: add pagefault and queue placement uapis

### DIFF
--- a/drm-uapi/xe_drm_prelim.h
+++ b/drm-uapi/xe_drm_prelim.h
@@ -70,9 +70,11 @@
  * components. Please add an unreserved ioctl number here to reserve that
  * number.
  */
+
 #define PRELIM_DRM_XE_EUDEBUG_CONNECT		0x5f
 #define PRELIM_DRM_XE_DEBUG_METADATA_CREATE	0x5e
 #define PRELIM_DRM_XE_DEBUG_METADATA_DESTROY	0x5d
+
 #define PRELIM_DRM_IOCTL_XE_EUDEBUG_CONNECT		DRM_IOWR(DRM_COMMAND_BASE + PRELIM_DRM_XE_EUDEBUG_CONNECT, struct prelim_drm_xe_eudebug_connect)
 #define PRELIM_DRM_IOCTL_XE_DEBUG_METADATA_CREATE	 DRM_IOWR(DRM_COMMAND_BASE + PRELIM_DRM_XE_DEBUG_METADATA_CREATE, struct prelim_drm_xe_debug_metadata_create)
 #define PRELIM_DRM_IOCTL_XE_DEBUG_METADATA_DESTROY	 DRM_IOW(DRM_COMMAND_BASE + PRELIM_DRM_XE_DEBUG_METADATA_DESTROY, struct prelim_drm_xe_debug_metadata_destroy)
@@ -95,8 +97,10 @@ struct prelim_drm_xe_vm_bind_op_ext_attach_debug {
 };
 
 #define PRELIM_XE_VM_BIND_OP_EXTENSIONS_ATTACH_DEBUG 0
+
 #define   PRELIM_DRM_XE_EXEC_QUEUE_SET_PROPERTY_EUDEBUG		2
 #define     PRELIM_DRM_XE_EXEC_QUEUE_EUDEBUG_FLAG_ENABLE		(1 << 0)
+
 /*
  * Debugger ABI (ioctl and events) Version History:
  * 0 - No debugger available
@@ -162,8 +166,6 @@ struct prelim_drm_xe_debug_metadata_destroy {
 	__u32 metadata_id;
 };
 
-#include "xe_drm_prelim.h"
-
 /**
  * Do a eudebug event read for a debugger connection.
  *
@@ -180,17 +182,21 @@ struct prelim_drm_xe_eudebug_event {
 	__u32 len;
 
 	__u16 type;
-#define PRELIM_DRM_XE_EUDEBUG_EVENT_NONE		0
-#define PRELIM_DRM_XE_EUDEBUG_EVENT_READ		1
-#define PRELIM_DRM_XE_EUDEBUG_EVENT_OPEN		2
-#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM			3
-#define PRELIM_DRM_XE_EUDEBUG_EVENT_EXEC_QUEUE		4
-#define PRELIM_DRM_XE_EUDEBUG_EVENT_EU_ATTENTION	5
-#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND		6
-#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_OP		7
-#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_UFENCE	8
-#define PRELIM_DRM_XE_EUDEBUG_EVENT_METADATA		9
-#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_OP_METADATA 10
+#define PRELIM_DRM_XE_EUDEBUG_EVENT_NONE			0
+#define PRELIM_DRM_XE_EUDEBUG_EVENT_READ			1
+#define PRELIM_DRM_XE_EUDEBUG_EVENT_OPEN			2
+#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM				3
+#define PRELIM_DRM_XE_EUDEBUG_EVENT_EXEC_QUEUE			4
+#define PRELIM_DRM_XE_EUDEBUG_EVENT_EU_ATTENTION		5
+#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND			6
+#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_OP			7
+#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_UFENCE		8
+#define PRELIM_DRM_XE_EUDEBUG_EVENT_METADATA			9
+#define PRELIM_DRM_XE_EUDEBUG_EVENT_VM_BIND_OP_METADATA		10
+#define PRELIM_DRM_XE_EUDEBUG_EVENT_PAGEFAULT			11
+#define PRELIM_DRM_XE_EUDEBUG_EVENT_SYNC_HOST			12
+#define PRELIM_DRM_XE_EUDEBUG_EVENT_EXEC_QUEUE_PLACEMENTS	13
+
 
 	__u16 flags;
 #define PRELIM_DRM_XE_EUDEBUG_EVENT_CREATE		(1 << 0)
@@ -226,6 +232,22 @@ struct prelim_drm_xe_eudebug_event_exec_queue {
 	__u64 lrc_handle[];
 };
 
+struct prelim_drm_xe_eudebug_event_exec_queue_placements {
+	struct prelim_drm_xe_eudebug_event base;
+
+	__u64 client_handle;
+	__u64 vm_handle;
+	__u64 exec_queue_handle;
+	__u64 lrc_handle;
+	__u32 num_placements;
+	__u32 pad;
+	/**
+	 * @instances: user pointer to num_placements sized array of struct
+	 * drm_xe_engine_class_instance
+	 */
+	__u64 instances[];
+};
+
 struct prelim_drm_xe_eudebug_event_eu_attention {
 	struct prelim_drm_xe_eudebug_event base;
 
@@ -239,10 +261,10 @@ struct prelim_drm_xe_eudebug_event_eu_attention {
 
 struct prelim_drm_xe_eudebug_eu_control {
 	__u64 client_handle;
-
 #define PRELIM_DRM_XE_EUDEBUG_EU_CONTROL_CMD_INTERRUPT_ALL	0
 #define PRELIM_DRM_XE_EUDEBUG_EU_CONTROL_CMD_STOPPED		1
 #define PRELIM_DRM_XE_EUDEBUG_EU_CONTROL_CMD_RESUME		2
+
 	__u32 cmd;
 	__u32 flags;
 
@@ -341,6 +363,7 @@ struct prelim_drm_xe_eudebug_vm_open {
 	/** @flags: flags */
 	__u64 flags;
 
+#define PRELIM_DRM_XE_EUDEBUG_VM_SYNC_MAX_TIMEOUT_NSECS (10ULL * NSEC_PER_SEC)
 	/** @timeout_ns: Timeout value in nanoseconds operations (fsync) */
 	__u64 timeout_ns;
 };
@@ -370,6 +393,18 @@ struct prelim_drm_xe_eudebug_event_vm_bind_op_metadata {
 
 	__u64 metadata_handle;
 	__u64 metadata_cookie;
+};
+
+struct prelim_drm_xe_eudebug_event_pagefault {
+	struct prelim_drm_xe_eudebug_event base;
+
+	__u64 client_handle;
+	__u64 exec_queue_handle;
+	__u64 lrc_handle;
+	__u32 flags;
+	__u32 bitmask_size;
+	__u64 pagefault_address;
+	__u8 bitmask[];
 };
 
 #endif /* _XE_DRM_PRELIM_H_ */


### PR DESCRIPTION
Aligned with v2 of eudebug dev which intorduced pagefault
support as well as exec queue placement

Signed-off-by: Ayaz A Siddiqui <ayaz.siddiqui@intel.com>