### PR TITLE
drm-uapi: move prelim header placement in xe_drm.h

### DIFF
--- a/drm-uapi/xe_drm.h
+++ b/drm-uapi/xe_drm.h
@@ -2530,8 +2530,6 @@ struct drm_xe_exec_queue_set_property {
 	__u64 reserved[2];
 };
 
-#include "xe_drm_prelim.h"
-
 /**
  * DOC: Xe DRM RAS
  *
@@ -2610,6 +2608,8 @@ enum drm_xe_ras_error_component {
 	[DRM_XE_RAS_ERR_COMP_CORE_COMPUTE] = "core-compute",		\
 	[DRM_XE_RAS_ERR_COMP_SOC_INTERNAL] = "soc-internal"		\
 }
+
+#include "xe_drm_prelim.h"
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
Update v7.1.1 drm-uapi headers with v7.1.1 which include header
position. This change is to align with xekmd-backport

Uapi is aligned with preview published at
GitHub - intel-gpu/xekmd-backports
Tag:v7.1.1.2

Signed-off-by: Pravalika Gurram <pravalika.gurram@intel.com>